### PR TITLE
Update perl command to support local lib

### DIFF
--- a/.bin/srclib-perl
+++ b/.bin/srclib-perl
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 // overall plan: https://witeboard.com/23562970-023d-11e8-8a7d-a99df8aed6ff
 
-var child_process = require('child_process')
 var _ = require('underscore')
 var parser = require('nomnom')
-
 var findPackages = require('../lib/findPackages')
 var utils = require('../lib/utils')
 
@@ -28,7 +26,7 @@ parser.command('scan')
         return {
           Name: pkg['id'],
           Type: 'CPANPackage',
-          Version: pkg['version'], 
+          Version: pkg['version'],
           Files: pkg['files'],
           Dir: '.',
           Dependencies: pkg['dependencies'],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 
 // instead of repeating the data structures returned in the method descriptions, I'll note
 // them here:
-// dependency_item: 
+// dependency_item:
 // {
 //      id: identifier,
 //      version: version of the module
@@ -14,9 +14,9 @@
 // {
 //  id: identifier,
 //  version: version of the source
-//  dependencies: {[dependency_item]}   
+//  dependencies: {[dependency_item]}
 // }
-// 
+//
 // untriaged_item:
 // [source_item, ...]
 
@@ -54,11 +54,11 @@ function extractMetaFromBuildList(file, dir) {
 }
 
 /**
- * Given the directory, find all the meta.json/yml files. This is either called after 
- * calling on the build type's meta fetchers (`cpanm --showdeps .`, `perl Makefile.pl`) or 
+ * Given the directory, find all the meta.json/yml files. This is either called after
+ * calling on the build type's meta fetchers (`cpanm --showdeps .`, `perl Makefile.pl`) or
  * one that was included in the module itself when downloaded
- * @param {string} dir 
- * 
+ * @param {string} dir
+ *
  * @return {[source_item]} an array of source items that we were able to gleam
  */
 function extractMetaFile(dir) {
@@ -140,7 +140,7 @@ function extractMyMetaYml(filePath) {
 
 function getDepsFromCpanfile(file, dir) {
   return new Promise(function (resolve, reject) {
-    child_process.exec('perl ' + CPANFILE_SCRIPT_LOCATION + ' ' + file, function (err, stdout, stderr) {
+    child_process.exec('perl -I ~/perl5/lib/perl5 ' + CPANFILE_SCRIPT_LOCATION + ' ' + file, function (err, stdout, stderr) {
       if (err || stderr) {
         // We don't need to error out, just console it
         // It is an issue however if mymeta and mymeta.yml are not made
@@ -156,7 +156,7 @@ function getDepsFromCpanfile(file, dir) {
       'version': null,
       'filePath': path.dirname(file)
     }
-    
+
     source_unit['dependencies'] = _
     .map(_.keys(reqs), function(dep_name) {
       return {
@@ -182,7 +182,7 @@ function getDepsFromCpanfile(file, dir) {
 function execMakefileOrBuildPL(file, dir) {
   file_loc = path.join(dir, file)
   return new Promise(function (resolve, reject) {
-    child_process.exec('cd ' + dir + '; perl ' + MAKEFILE_PL_SCRIPT_LOCATION + ' ' + file, function (err, stdout, stderr) {
+    child_process.exec('cd ' + dir + '; perl  -I ~/perl5/lib/perl5 ' + MAKEFILE_PL_SCRIPT_LOCATION + ' ' + file, function (err, stdout, stderr) {
       if (err || stderr) {
         console.error('Failed to parse MakeFile/Build.PL')
       }


### PR DESCRIPTION
Changes the perl command from `perl` to `perl -I ~/perl5/lib/perl5` so that installed libraries load from the user's home directory.

This is in line with how Perl is installed in the new image.
https://github.com/fossas/FOSSA/blob/d9837ed9b89c89847186836d31daaa5738c41693/docker/srclib/Dockerfile#L16-L29